### PR TITLE
adds per app bus logic

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -10,6 +10,17 @@ type app struct {
 	name string
 
 	builds map[string][]Build
+	bus    *appbus
+}
+
+// NewApp will return a new app with the given name, the name should also be the directory name that the app will
+// search for config data in
+func NewApp(name string) App {
+	return &app{
+		name:   name,
+		builds: make(map[string][]Build),
+		bus:    newAppBus(),
+	}
 }
 
 // Name is the apps name
@@ -29,17 +40,30 @@ func (a *app) Config(namespace string, conf interface{}) error {
 
 // SendEvent will send the given string on the apps event bus
 func (a *app) SendEvent(event string) {
+	if a == nil {
+		return
+	}
 
+	a.bus.Emit(event)
 }
 
 // Listen will provide a channel to select on for a given regular expression
 // returned map is the captured groups and values
-func (a *app) Listen(event string, listener func(map[string]string)) EventHandler {
-	return 0
+func (a *app) Listen(expr string, listener func(map[string]string)) EventHandler {
+	if a == nil {
+		return EventHandler(0)
+	}
+
+	handler, _ := a.bus.AddListener(expr, listener)
+	return handler
 }
 
-func (a *app) RemoveEventHandler(EventHandler) {
+func (a *app) RemoveEventHandler(handler EventHandler) {
+	if a == nil {
+		return
+	}
 
+	a.bus.RemoveHandler(handler)
 }
 
 func (a *app) NewBuild(group string, config *BuildConfig) (token string, err error) {

--- a/core/appbus.go
+++ b/core/appbus.go
@@ -1,0 +1,134 @@
+package core
+
+import (
+	"errors"
+	"regexp"
+	"sync"
+	"sync/atomic"
+)
+
+type appbuslistener struct {
+	fn      func(map[string]string)
+	handler EventHandler
+}
+
+type appbus struct {
+	m         sync.RWMutex
+	listeners map[*regexp.Regexp][]appbuslistener
+
+	events     chan string
+	Done       chan struct{}
+	closed     uint64
+	handlerctr uint64
+}
+
+func newAppBus() *appbus {
+	bus := &appbus{
+		listeners: make(map[*regexp.Regexp][]appbuslistener),
+		events:    make(chan string, 128),
+		Done:      make(chan struct{}, 1),
+	}
+	go bus.coreloop()
+	return bus
+}
+
+func (bus *appbus) AddListener(expr string, listener func(map[string]string)) (EventHandler, error) {
+	if bus == nil {
+		return EventHandler(0), errors.New("bus is nil")
+	}
+
+	if atomic.LoadUint64(&bus.closed) > 0 {
+		return EventHandler(0), errors.New("bus is closed")
+	}
+
+	bus.m.Lock()
+	defer bus.m.Unlock()
+	var foundKey *regexp.Regexp
+	for key := range bus.listeners {
+		if key.String() == expr {
+			foundKey = key
+			break
+		}
+	}
+
+	if foundKey != nil {
+		handler := atomic.AddUint64(&bus.handlerctr, 1)
+		listeners := append(bus.listeners[foundKey], appbuslistener{listener, EventHandler(handler)})
+		bus.listeners[foundKey] = listeners
+
+		return EventHandler(handler), nil
+	}
+
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return 0, err
+	}
+
+	handler := atomic.AddUint64(&bus.handlerctr, 1)
+	listeners := append(bus.listeners[re], appbuslistener{listener, EventHandler(handler)})
+	bus.listeners[re] = listeners
+
+	return EventHandler(handler), nil
+}
+
+func (bus *appbus) RemoveHandler(handler EventHandler) {
+	if bus == nil {
+		return
+	}
+	bus.m.Lock()
+	defer bus.m.Unlock()
+
+	// this is slow but is mostly here for completion purposes. if this gets used more than i think, we might have to redo
+	for key, listeners := range bus.listeners {
+		for i, listener := range listeners {
+			if listener.handler == handler {
+				bus.listeners[key] = append(listeners[:i], listeners[i+1:]...)
+			}
+		}
+
+		if len(bus.listeners[key]) < 1 {
+			delete(bus.listeners, key)
+			break
+		}
+
+	}
+}
+
+func (bus *appbus) Emit(action string) {
+	if bus == nil || atomic.LoadUint64(&bus.closed) > 0 {
+		return
+	}
+
+	bus.events <- action
+}
+
+func (bus *appbus) coreloop() {
+coreloop:
+	for {
+		select {
+		case event := <-bus.events:
+			bus.fireEvent(event)
+		case <-bus.Done:
+			atomic.StoreUint64(&bus.closed, 1)
+			break coreloop
+		}
+	}
+}
+
+func (bus *appbus) fireEvent(event string) {
+	bus.m.RLock()
+	defer bus.m.RUnlock()
+
+	// we could make this smoother by unlocking earlier and copying the slices of listeners that need to be fired
+	// but it would make Remove strange, events would be fired after Remove()
+	for re, listeners := range bus.listeners {
+		matches, err := RegexpNamedGroupsMatch(re, event)
+		if err != nil {
+			continue
+		}
+
+		for _, listener := range listeners {
+			listener.fn(matches)
+		}
+	}
+}

--- a/core/appbus_test.go
+++ b/core/appbus_test.go
@@ -1,0 +1,91 @@
+package core
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppBus(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	bus := newAppBus()
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	handler, err := bus.AddListener("test", func(names map[string]string) {
+		assert.Len(names, 0)
+		wg.Done()
+	})
+	require.NoError(err)
+
+	bus.Emit("test")
+	wg.Wait()
+
+	bus.RemoveHandler(handler)
+	assert.Len(bus.listeners, 0)
+	bus.Done <- struct{}{}
+	<-time.After(time.Millisecond)
+
+	_, err = bus.AddListener("test", func(map[string]string) {})
+	assert.Error(err)
+}
+
+func TestAppBusNamedGroups(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	bus := newAppBus()
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	test1marker := "teststring"
+	test2marker := "1234567890"
+
+	handler, err := bus.AddListener(`(?P<test1>[a-z]+):(?P<test2>[0-9]+)`, func(names map[string]string) {
+		assert.EqualValues(test1marker, names["test1"])
+		assert.EqualValues(test2marker, names["test2"])
+		wg.Done()
+	})
+	require.NoError(err)
+
+	bus.Emit(fmt.Sprintf("%s:%s", test1marker, test2marker))
+	wg.Wait()
+
+	bus.RemoveHandler(handler)
+	assert.Len(bus.listeners, 0)
+	bus.Done <- struct{}{}
+}
+
+func TestAppBusManyListeners(t *testing.T) {
+	require := require.New(t)
+
+	bus := newAppBus()
+	wg1 := sync.WaitGroup{}
+	wg2 := sync.WaitGroup{}
+
+	for i := 0; i < 10; i++ {
+		wg1.Add(1)
+		wg2.Add(1)
+		_, err := bus.AddListener("test1", func(names map[string]string) {
+			wg1.Done()
+		})
+		require.NoError(err)
+		_, err = bus.AddListener("test2", func(names map[string]string) {
+			wg2.Done()
+		})
+		require.NoError(err)
+	}
+
+	bus.Emit("test1")
+	wg1.Wait()
+
+	bus.Emit("test2")
+	wg2.Wait()
+	bus.Done <- struct{}{}
+}

--- a/core/regex.go
+++ b/core/regex.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"errors"
+	"regexp"
+)
+
+var (
+	errNoMatch = errors.New("Could not match regexp")
+)
+
+// RegexpNamedGroupsMatch - will for a given regexp and search give you a a map of named groups to found values
+func RegexpNamedGroupsMatch(pattern *regexp.Regexp, search string) (namedGroupMatch map[string]string, err error) {
+	if pattern.MatchString(search) == false {
+		err = errNoMatch
+		return
+	}
+	namedGroupMatch = make(map[string]string)
+	groups := pattern.SubexpNames()
+	for _, group := range groups {
+		if group == "" {
+			continue
+		}
+		namedGroupMatch[group] = ""
+	}
+
+	for index, submatch := range pattern.FindStringSubmatch(search) {
+		// first returned value is just the entire string, which is totally useful. skip it.
+		if index < 1 {
+			continue
+		}
+		namedGroupMatch[groups[index]] = submatch
+	}
+
+	return
+}

--- a/core/regex_test.go
+++ b/core/regex_test.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testregexpmatch struct {
+	pattern *regexp.Regexp
+	search  string
+	result  map[string]string
+}
+
+func TestregexpmatchNamedGroupsMatch(t *testing.T) {
+	testData := []testregexpmatch{
+		testregexpmatch{
+			pattern: regexp.MustCompile(`(?P<1>\d)(?P<2>\d)`),
+			search:  "12",
+			result: map[string]string{
+				"1": "1",
+				"2": "2",
+			},
+		},
+		testregexpmatch{
+			pattern: regexp.MustCompile(`(?P<1>\d)(?P<2>-)?(?P<3>\d)`),
+			search:  "13",
+			result: map[string]string{
+				"1": "1",
+				"2": "",
+				"3": "3",
+			},
+		},
+	}
+
+	for _, testData := range testData {
+		match, err := RegexpNamedGroupsMatch(testData.pattern, testData.search)
+		assert.Nil(t, err)
+		assert.Equal(t, testData.result, match)
+	}
+}


### PR DESCRIPTION
appbus should be fast enough, the same regex's passed in twice are consolidated into one compiled regexp so it's about as efficient as you can get with this kind of a design 

one added goroutine per app should be fine also 
