### PR TITLE
Adds a basic config system through App.Config

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -23,8 +23,12 @@ func (a *app) Name() string {
 
 // Config will apply the config at namespace onto the given conf structure
 // consider this like json.Unmarshal()
-func (a *app) Config(namespace string, conf interface{}) error {
-	return nil
+func (a *app) Config(integrationName string, conf interface{}) error {
+	if a == nil {
+		return errors.New("a is nil")
+	}
+
+	return applyIntegrationConfig(a.name, integrationName, conf)
 }
 
 // SendEvent will send the given string on the apps event bus

--- a/core/config.go
+++ b/core/config.go
@@ -1,0 +1,118 @@
+package core
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"sync"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+type config map[string]interface{}
+
+var (
+	// TODO - make this adjustable with envvar or something
+	configBaseDir   = ""
+	configCacheLock sync.RWMutex
+	configCache     = make(map[string]config)
+)
+
+func loadConfig(path string) (config, error) {
+	configCacheLock.RLock()
+	if c, ok := configCache[path]; ok {
+		configCacheLock.RUnlock()
+		return c, nil
+	}
+	configCacheLock.RUnlock()
+
+	raw, err := ioutil.ReadFile(filepath.Join(configBaseDir, path))
+	if err != nil {
+		return nil, err
+	}
+
+	var conf interface{}
+	err = json.Unmarshal(raw, &conf)
+	if err != nil {
+		return nil, err
+	}
+
+	configCacheLock.Lock()
+	defer configCacheLock.Unlock()
+	configCache[path] = (config)(conf.(map[string]interface{}))
+
+	return configCache[path], nil
+}
+
+func loadMasterConfig() (config, error) {
+	return loadConfig("ngbuild.json")
+}
+
+func loadAppConfig(appname string) (config, error) {
+	return loadConfig(filepath.Join("apps", appname, "config.json"))
+}
+
+// for the given config, apply it's data onto the given structure s
+func applyConfig(appname string, s interface{}) error {
+	master, err := loadMasterConfig()
+	if err != nil {
+		return err
+	}
+
+	if err = mapstructure.Decode(master, s); err != nil {
+		return err
+	}
+
+	if appname != "" {
+		appconfig, err := loadAppConfig(appname)
+		if err != nil {
+			return err
+		}
+
+		return mapstructure.Decode(appconfig, s)
+	}
+	return nil
+}
+
+func getIntegrationConfig(conf config, integrationName string) config {
+	if integrations, ok := conf["Integrations"]; ok == false {
+		return nil
+	} else if integrationsMap, ok := integrations.(map[string]interface{}); ok == false {
+		return nil
+	} else if integration, ok := integrationsMap[integrationName]; ok == false {
+		return nil
+	} else if integrationMap, ok := integration.(map[string]interface{}); ok == false {
+		return nil
+	} else {
+		return (config)(integrationMap)
+	}
+}
+
+// Like applyConfig, but will look for configs in /integrations/integrationName/
+func applyIntegrationConfig(appname, integrationName string, s interface{}) error {
+	master, err := loadMasterConfig()
+	if err != nil {
+		return err
+	}
+
+	if masterIntegration := getIntegrationConfig(master, integrationName); masterIntegration != nil {
+		if err = mapstructure.Decode(masterIntegration, s); err != nil {
+			return err
+		}
+	}
+
+	if appname != "" {
+		appconfig, err := loadAppConfig(appname)
+		if err != nil {
+			return err
+		}
+
+		if appIntegration := getIntegrationConfig(appconfig, integrationName); appIntegration != nil {
+			if err = mapstructure.Decode(appIntegration, s); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -1,0 +1,44 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyConfig(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	previousBaseDir := configBaseDir
+	configBaseDir = "testdata"
+	configCache = make(map[string]config) // clear out the cache
+
+	mc, err := loadMasterConfig()
+	require.NoError(err)
+
+	ac, err := loadAppConfig("testapp")
+	require.NoError(err)
+	assert.NotEqual(mc["Foo"], ac["Foo"], "ensures that the app config overrides master")
+
+	type NormalConf struct {
+		Foo string
+		Bar string
+	}
+
+	normal := NormalConf{}
+	err = applyConfig("testapp", &normal)
+	require.NoError(err)
+	assert.EqualValues(NormalConf{"a different string", "something else"}, normal)
+
+	type IntegrationConf struct {
+		Foo string
+		Baz string
+	}
+	integration := IntegrationConf{}
+	err = applyIntegrationConfig("testapp", "testintegration", &integration)
+	require.NoError(err)
+	assert.EqualValues(IntegrationConf{"A different bar", "FooBarBaz"}, integration)
+
+	configBaseDir = previousBaseDir
+}

--- a/core/testdata/apps/testapp/config.json
+++ b/core/testdata/apps/testapp/config.json
@@ -1,0 +1,8 @@
+{
+    "Foo": "a different string",
+    "Integrations": {
+        "testintegration": {
+            "Foo": "A different bar"
+        }
+    }
+}

--- a/core/testdata/ngbuild.json
+++ b/core/testdata/ngbuild.json
@@ -1,0 +1,10 @@
+{
+    "Foo": "a test string",
+    "Bar": "something else",
+    "Integrations": {
+        "testintegration": {
+            "Foo": "Bar",
+            "Baz": "FooBarBaz"
+        }
+    }
+}


### PR DESCRIPTION
simple config system inspired by json.Unmarshal and the like, basically
give it a structure and your integration name and it will fill it out as
you expect

config format is json (for now) but could be basically anything that can
unmarshal to a map[string]interface{}

loose config format is such that top level stuff is reserved for
Core/main and Integrations/<integrationName>/ is mapped onto whatever
structure you provide

in addition, first ngbuild.json is loaded, then the app specific
config.json is loaded, config.json will overwrite ngbuild.json

github.com/mitchellh/mapstructure is used to map the
map[string]interface{} onto structures, seems good
