### PR TITLE
adds zombie detection for nodejs issues

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -126,7 +126,9 @@ func (a *app) Shutdown() {
 	}
 	for _, builds := range a.builds {
 		for _, build := range builds {
-			build.Stop()
+			if build.HasStopped() == false {
+				build.Stop()
+			}
 		}
 	}
 }
@@ -248,13 +250,13 @@ func (a *app) GetBuildHistory(group string) []Build {
 
 func (a *app) Loginfof(str string, args ...interface{}) {
 	args = append([]interface{}{a.Name()}, args...)
-	log := logcritf("(%s):"+str, args...)
+	log := loginfof("(%s):"+str, args...)
 	a.SendEvent(fmt.Sprintf("/log/app:%s/logtype:crit/%s", a.Name(), log))
 }
 
 func (a *app) Logwarnf(str string, args ...interface{}) {
 	args = append([]interface{}{a.Name()}, args...)
-	log := logcritf("(%s):"+str, args...)
+	log := logwarnf("(%s):"+str, args...)
 	a.SendEvent(fmt.Sprintf("/log/app:%s/logtype:warn/%s", a.Name(), log))
 }
 

--- a/core/stdpipes_test.go
+++ b/core/stdpipes_test.go
@@ -31,6 +31,10 @@ func (m *mockReader) Read(p []byte) (int, error) {
 	return m.readFn(p)
 }
 
+func (m *mockReader) Close() error {
+	return nil
+}
+
 func TestStdPipes(t *testing.T) {
 	assert := assert.New(t)
 	testMarker := []byte("::testmarker::")


### PR DESCRIPTION
nodejs will often exit but keep stdout/stderr open, which means the normal way of launching unix processes falls down (that is, execute program, listen to stdout/err pipes, when they close call wait()), because the pipes never close, we never wait.

so i've built automatic zombie process detection (only works on linux), there are more unixy way of doing things here but golang gets in the way of those so this should do, builds might take an extra 5 seconds to complete, it's file 