### PR TITLE
[slack] messageResponse struct incorrectly changed to mapstructure

### DIFF
--- a/integrations/slack/slack.go
+++ b/integrations/slack/slack.go
@@ -49,7 +49,7 @@ type (
 	}
 
 	messageParams struct {
-		Attachments []slack.Attachment `mapstructure:"attachments"`
+		Attachments []slack.Attachment `json:"attachments"`
 	}
 
 	config struct {


### PR DESCRIPTION
Fixes the rebuild button