### PR TITLE
[core] fixes issues with stdpipes and many threads

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -42,7 +42,7 @@ func GetApps() []App {
 		enabledIntegrations := struct {
 			EnabledIntegrations []string `mapstructure:"enabledIntegrations"`
 		}{}
-		applyConfig(name, &enabledIntegrations)
+		applyConfig(name, &enabledIntegrations) //nolint (errcheck)
 
 		integrations := GetIntegrations()
 		// christ this code, will remove all but the 'enabledIntegrations' from our integrations list
@@ -97,7 +97,7 @@ func newApp(name, appLocation string, integrations []Integration) App {
 	}
 
 	for _, integration := range integrations {
-		integration.AttachToApp(app)
+		integration.AttachToApp(app) //nolint (errcheck)
 	}
 	return app
 }
@@ -127,7 +127,7 @@ func (a *app) Shutdown() {
 	for _, builds := range a.builds {
 		for _, build := range builds {
 			if build.HasStopped() == false {
-				build.Stop()
+				build.Stop() //nolint (errcheck)
 			}
 		}
 	}
@@ -188,7 +188,7 @@ func (a *app) NewBuild(group string, config *BuildConfig) (token string, err err
 	var appcfg struct {
 		BuildRunner string `mapstructure:"buildRunner"`
 	}
-	applyConfig(a.Name(), &appcfg)
+	applyConfig(a.Name(), &appcfg) //nolint (errcheck)
 
 	config.BuildRunner = "build.sh"
 	if appcfg.BuildRunner != "" {

--- a/core/build_test.go
+++ b/core/build_test.go
@@ -252,7 +252,7 @@ func getSuccessfulIntegration() *MockIntegration {
 		dir := args.Get(1).(string)
 		//FIXME - this is lazy, stops tests running on windows, is bad in general, i'm so tired
 		cmd := exec.Command("cp", "testdata/failure.sh", "testdata/success.sh", "testdata/fiveminutes.sh", dir)
-		cmd.Run()
+		cmd.Run() //nolint (errcheck)
 	}).Return(nil)
 	return i
 }

--- a/core/copy.go
+++ b/core/copy.go
@@ -26,16 +26,16 @@ func writeAll(f io.Writer, buf []byte) error {
 func CopyFile(src, dst string) error {
 	_, name := filepath.Split(src)
 	tmpFile, err := ioutil.TempFile(os.TempDir(), name)
-	defer tmpFile.Close()
+	defer tmpFile.Close() //nolint (errcheck)
 	if err != nil {
 		return err
 	}
 
 	tmpFileName := tmpFile.Name()
-	defer os.Remove(tmpFileName)
+	defer os.Remove(tmpFileName) //nolint (errcheck)
 
 	srcFile, err := os.Open(src)
-	defer srcFile.Close()
+	defer srcFile.Close() //nolint (errcheck)
 	if err != nil {
 		return err
 	}
@@ -48,12 +48,12 @@ func CopyFile(src, dst string) error {
 			return err
 		}
 
-		writeAll(tmpFile, buf[:n])
+		writeAll(tmpFile, buf[:n]) //nolint (errcheck)
 	}
 
 	// if we get here, tmpFile has a copy of src
-	tmpFile.Close()
-	srcFile.Close()
+	tmpFile.Close() //nolint (errcheck)
+	srcFile.Close() //nolint (errcheck)
 
 	return os.Rename(tmpFileName, dst)
 }

--- a/core/copy_test.go
+++ b/core/copy_test.go
@@ -19,8 +19,8 @@ func TestCopyFile(t *testing.T) {
 	}
 
 	srcFile, err := ioutil.TempFile(os.TempDir(), "testcopyfile")
-	defer srcFile.Close()
-	defer os.Remove(srcFile.Name())
+	defer srcFile.Close()           //nolint (errcheck)
+	defer os.Remove(srcFile.Name()) //nolint (errcheck)
 
 	require.NoError(err)
 	dstLocation := srcFile.Name() + "destFile"
@@ -28,7 +28,7 @@ func TestCopyFile(t *testing.T) {
 	require.NoError(writeAll(srcFile, []byte(testData)))
 	require.NoError(srcFile.Close())
 	require.NoError(CopyFile(srcFile.Name(), dstLocation))
-	defer os.Remove(dstLocation)
+	defer os.Remove(dstLocation) //nolint (errcheck)
 
 	copiedFile, err := ioutil.ReadFile(dstLocation)
 	require.NoError(err)

--- a/core/core.go
+++ b/core/core.go
@@ -222,9 +222,9 @@ func CacheDirectory() string {
 	cfgCache := struct {
 		CacheDirectory string `mapstructure:"cacheDirectory"`
 	}{}
-	applyConfig("", &cfgCache)
+	applyConfig("", &cfgCache) //nolint (errcheck)
 
-	os.MkdirAll(cfgCache.CacheDirectory, 0755)
+	os.MkdirAll(cfgCache.CacheDirectory, 0755) //nolint (errcheck)
 	return cfgCache.CacheDirectory
 }
 
@@ -296,7 +296,7 @@ func StartHTTPServer() chan struct{} {
 		cfg := struct {
 			HTTPListenPort string `mapstructure:"httpListenPort"`
 		}{}
-		applyConfig("", &cfg)
+		applyConfig("", &cfg) //nolint (errcheck)
 
 		loginfof("Starting http listen server on :%s", cfg.HTTPListenPort)
 		if err := http.ListenAndServe(":"+cfg.HTTPListenPort, nil); err != nil {
@@ -313,7 +313,7 @@ func GetHTTPServerURL() string {
 		HTTPListenPort string `mapstructure:"httpListenPort"`
 		Hostname       string `mapstructure:"hostname"`
 	}{}
-	applyConfig("", &cfg)
+	applyConfig("", &cfg) // nolint (errcheck)
 
 	if cfg.HTTPListenPort == "80" {
 		return fmt.Sprintf("http://%s", cfg.Hostname)
@@ -326,18 +326,18 @@ func GetHTTPServerURL() string {
 
 func loginfof(str string, args ...interface{}) (ret string) {
 	ret = fmt.Sprintf("info: "+str+"\n", args...)
-	fmt.Printf(ret)
+	fmt.Print(ret)
 	return ret
 }
 
 func logwarnf(str string, args ...interface{}) (ret string) {
 	ret = fmt.Sprintf("warn: "+str+"\n", args...)
-	fmt.Printf(ret)
+	fmt.Print(ret)
 	return ret
 }
 
 func logcritf(str string, args ...interface{}) (ret string) {
 	ret = fmt.Sprintf("crit: "+str+"\n", args...)
-	fmt.Printf(ret)
+	fmt.Print(ret)
 	return ret
 }

--- a/core/gentoken.go
+++ b/core/gentoken.go
@@ -19,9 +19,9 @@ var (
 func generateToken(prefix ...string) string {
 	hasher := sha256.New()
 
-	hasher.Write([]byte(salt))
-	binary.Write(hasher, binary.LittleEndian, time.Now().UTC().UnixNano())
-	binary.Write(hasher, binary.LittleEndian, atomic.AddUint64(&ctr, 1))
+	hasher.Write([]byte(salt))                                             //nolint (errcheck)
+	binary.Write(hasher, binary.LittleEndian, time.Now().UTC().UnixNano()) //nolint (errcheck)
+	binary.Write(hasher, binary.LittleEndian, atomic.AddUint64(&ctr, 1))   //nolint (errcheck)
 
 	return strings.Join(prefix, "-") + base64.URLEncoding.EncodeToString(hasher.Sum(nil))[:16]
 }


### PR DESCRIPTION
stdpipes was overly complex and overly engineered, the basic idea behind
it was that you want to have one stdout, but many different things
.Read()ing on that stdout

this can obviously get a bit complicated as reading once changes the
position, so the structure was built to multiplex one reader over many
structures via a cache

previously it handled stdout and stderr at the same time, which was
overly complex so now it just handles one pipe

in addition there was a problem with it's logic, it had races with the
GetCache() method, the conditional sync structure would cause races with
the stdpipes mutex, causing deadlocks.

now everything simply doesn't lock the stdpipes mutex until they know
they have new data to read or the stdpipe was closed

in addition, some gometalinter fixes to core to get errors out of my
face