### PR TITLE
fix crasher on rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 ngbuild
+ngbuild.json
+apps/
 integrations/slack/bin

--- a/core/buildconfig.go
+++ b/core/buildconfig.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/json"
 	"io/ioutil"
+	"sync"
 )
 
 // SetMetadata will set metadata
@@ -62,6 +63,7 @@ func UnmarshalBuildConfig(filename string) (*BuildConfig, error) {
 		return nil, err
 	}
 	conf := marshalledConf.Config
+	conf.m = &sync.RWMutex{}
 	conf.metadata = make(map[string]string)
 	// there isn't a nice way of copying a map in go.. so here we go
 	for key, value := range *marshalledConf.Metadata {


### PR DESCRIPTION
this (probably, is untested) fixes the crash when rebuilding anything in
ngbuild. some time ago some bugs were fixed related to how we were
creating Build structures, which meant that the previously allocated as
a value sync primative inside BuildConfig got moved into a reference

when we do a rebuild we create a BuildConfig but we wern't creating the
sync primative as well, which meant it was nil and explosions happened

this is untested as LXD is a pain and doesn't have a nice way of
forwarding ports - they want you to mess about with ip tables like it is
the early 2000s seriously

fixes #32